### PR TITLE
add scopes back

### DIFF
--- a/step3/map.html
+++ b/step3/map.html
@@ -33,10 +33,11 @@ limitations under the License.
     // Client ID for OAuth 2.0 authorization against BigQuery.
     let clientId = 'YOUR_CLIENT_ID';
     let map;
+    let scopes = 'https://www.googleapis.com/auth/bigquery';
 
     // Check if the user is authorized.
     function authorize(event) {
-      gapi.auth.authorize({client_id: clientId, immediate: false}, handleAuthResult);
+      gapi.auth.authorize({client_id: clientId, scope: scopes, immediate: false}, handleAuthResult);
       return false;
     }
 

--- a/step4/map.html
+++ b/step4/map.html
@@ -32,6 +32,7 @@ limitations under the License.
     <script type="text/javascript">
     // Client ID for OAuth 2.0 authorization against BigQuery.
     let clientId = 'YOUR_CLIENT_ID';
+    let scopes = 'https://www.googleapis.com/auth/bigquery';
     // BigQuery settings. Replace these with your project, dataset and table names.
     let gcpProjectId = 'YOUR_PROJECT_ID';
     let bigQueryProjectId = 'bigquery-public-data';
@@ -43,7 +44,7 @@ limitations under the License.
 
     // Check if the user is authorized.
     function authorize(event) {
-      gapi.auth.authorize({client_id: clientId, immediate: false}, handleAuthResult);
+      gapi.auth.authorize({client_id: clientId, scope: scopes, immediate: false}, handleAuthResult);
       return false;
     }
 

--- a/step5/map.html
+++ b/step5/map.html
@@ -32,6 +32,7 @@ limitations under the License.
     <script type="text/javascript">
     // Client ID for OAuth 2.0 authorization against BigQuery.
     let clientId = 'YOUR_CLIENT_ID';
+    let scopes = 'https://www.googleapis.com/auth/bigquery';
 
     // BigQuery settings. Replace these with your project, dataset and table names.
     let gcpProjectId = 'YOUR_PROJECT_ID';
@@ -49,7 +50,7 @@ limitations under the License.
 
     // Check if the user is authorized.
     function authorize(event) {
-      gapi.auth.authorize({client_id: clientId, immediate: false}, handleAuthResult);
+      gapi.auth.authorize({client_id: clientId, scope: scopes, immediate: false}, handleAuthResult);
       return false;
     }
 

--- a/step6/map.html
+++ b/step6/map.html
@@ -32,6 +32,7 @@ limitations under the License.
     <script type="text/javascript">
     // Client ID for OAuth 2.0 authorization against BigQuery.
     let clientId = 'YOUR_CLIENT_ID';
+    let scopes = 'https://www.googleapis.com/auth/bigquery';
 
     // BigQuery settings. Replace these with your project, dataset and table names.
     let gcpProjectId = 'YOUR_PROJECT_ID';
@@ -49,7 +50,7 @@ limitations under the License.
 
     // Check if the user is authorized.
     function authorize(event) {
-      gapi.auth.authorize({client_id: clientId, immediate: false}, handleAuthResult);
+      gapi.auth.authorize({client_id: clientId, scope: scopes, immediate: false}, handleAuthResult);
       return false;
     }
 

--- a/step7/map.html
+++ b/step7/map.html
@@ -32,6 +32,7 @@ limitations under the License.
     <script type="text/javascript">
     // Client ID for OAuth 2.0 authorization against BigQuery.
     let clientId = 'YOUR_CLIENT_ID';
+    let scopes = 'https://www.googleapis.com/auth/bigquery';
 
     // BigQuery settings. Replace these with your project, dataset and table names.
     let gcpProjectId = 'YOUR_PROJECT_ID';
@@ -49,7 +50,7 @@ limitations under the License.
 
     // Check if the user is authorized.
     function authorize(event) {
-      gapi.auth.authorize({client_id: clientId, immediate: false}, handleAuthResult);
+      gapi.auth.authorize({client_id: clientId, scope: scopes, immediate: false}, handleAuthResult);
       return false;
     }
 

--- a/step8/map.html
+++ b/step8/map.html
@@ -57,6 +57,7 @@ limitations under the License.
     <script type="text/javascript">
     // Client ID for OAuth 2.0 authorization against BigQuery.
     let clientId = 'YOUR_CLIENT_ID';
+    let scopes = 'https://www.googleapis.com/auth/bigquery';
 
     // BigQuery settings. Replace these with your project, dataset and table names.
     let gcpProjectId = 'YOUR_PROJECT_ID';
@@ -74,7 +75,7 @@ limitations under the License.
 
     // Check if the user is authorized.
     function authorize(event) {
-      gapi.auth.authorize({client_id: clientId, immediate: false}, handleAuthResult);
+      gapi.auth.authorize({client_id: clientId, scope: scopes, immediate: false}, handleAuthResult);
       return false;
     }
 


### PR DESCRIPTION
Call to gapi.auth.authorize would fail without scopes.